### PR TITLE
Formalization of a storage implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,18 @@ An implementation of a *[tus](https://tus.io/)* **server** in Elixir
 > An interruption may happen willingly, if the user wants to pause,
 > or by accident in case of an network issue or server outage.
 
-It's currently capable of accepting uploads with arbitrary sizes and storing them locally
-on disk; or in Amazon S3, by installing the [`tus_storage_s3`](https://hex.pm/packages/tus_storage_s3) hex package.
-Due to its modularization and extensibility, support for any other cloud provider can be easily added.
+Files being uploaded should eventually be stored somewhere. This serverside implementation defines
+the [`Tus.Storage`](lib/tus/storage.ex) Elixir behaviour defining the callbacks which must be implemented. 
+Current implementations are:
+* [local file system](lib/tus/storage/local.ex) (provided by this package)
+* [`tus_storage_s3`](https://hex.pm/packages/tus_storage_s3) to save the files on Amazon S3.
+
+Due to its modularization and extensibility, support for any other cloud provider 
+or custom processing can be easily added.
 
 ## Features
 
 This library implements the core TUS API v1.0.0 protocol and the following extensions:
 
-- Creation Protocol (http://tus.io/protocols/resumable-upload.html#creation). Deferring the upload's length is not possible.
-- Termination Protocol (http://tus.io/protocols/resumable-upload.html#termination)
-
+- [Creation Protocol](http://tus.io/protocols/resumable-upload.html#creation) - Deferring the upload's length is not possible.
+- [Termination Protocol](http://tus.io/protocols/resumable-upload.html#termination)

--- a/lib/tus.ex
+++ b/lib/tus.ex
@@ -17,8 +17,8 @@ defmodule Tus do
 
   This library implements the core TUS API v1.0.0 protocol and the following extensions:
 
-  - Creation Protocol (http://tus.io/protocols/resumable-upload.html#creation). Deferring the upload's length is not possible.
-  - Termination Protocol (http://tus.io/protocols/resumable-upload.html#termination)
+  - [Creation Protocol](http://tus.io/protocols/resumable-upload.html#creation) - Deferring the upload's length is not possible.
+  - [Termination Protocol](http://tus.io/protocols/resumable-upload.html#termination)
 
 
   ## Installation
@@ -47,7 +47,7 @@ defmodule Tus do
       ...
       :ok  # or {:error, reason} to reject the uplaod
     end
-    
+
     # Completed upload optional callback
     def on_complete_upload(file) do
       ...
@@ -70,7 +70,7 @@ defmodule Tus do
   **3. Add config for each controller (see next section)**
 
 
-  ## Configuration (the global way) 
+  ## Configuration (the global way)
 
   ```elixir
   # List here all of your upload controllers
@@ -98,7 +98,7 @@ defmodule Tus do
     [`tus_cache_redis`](https://hex.pm/packages/tus_cache_redis) hex package to use a **Redis** based one.
 
   - `max_size`:
-    hard limit on the maximum size an uploaded file can have 
+    hard limit on the maximum size an uploaded file can have
 
   ### Options for `Tus.Storage.Local`
 

--- a/lib/tus/file.ex
+++ b/lib/tus/file.ex
@@ -2,7 +2,7 @@ defmodule Tus.File do
   @enforce_keys [:uid]
 
   defstruct uid: nil,
-            size: nil,
+            size: 0,
             offset: 0,
             metadata_src: nil,
             metadata: %{},
@@ -10,4 +10,16 @@ defmodule Tus.File do
             path: nil,
             parts: [],
             upload_id: nil
+
+  @type t() :: %__MODULE__{
+          uid: String.t(),
+          size: integer(),
+          offset: integer(),
+          metadata_src: String.t(),
+          metadata: map(),
+          created_at: integer(),
+          path: String.t(),
+          parts: list(tuple()),
+          upload_id: String.t()
+        }
 end

--- a/lib/tus/post.ex
+++ b/lib/tus/post.ex
@@ -54,6 +54,7 @@ defmodule Tus.Post do
     metadata_src
     |> String.split(~r/\s*,\s*/)
     |> Enum.map(&split_metadata/1)
+    |> Map.new()
   end
 
   defp split_metadata(kv) do

--- a/lib/tus/post.ex
+++ b/lib/tus/post.ex
@@ -12,7 +12,7 @@ defmodule Tus.Post do
          :ok <- config.on_begin_upload.(file) do
       conn
       |> put_resp_header("tus-resumable", config.version)
-      |> put_resp_header("location", file.uid)
+      |> put_resp_header("location", conn.request_path <> file.uid)
       |> resp(:created, "")
     else
       :too_large ->
@@ -36,7 +36,7 @@ defmodule Tus.Post do
       if metadata_src do
         parse_metadata(metadata_src)
       else
-        nil
+        %{}
       end
 
     file = %Tus.File{

--- a/lib/tus/storage.ex
+++ b/lib/tus/storage.ex
@@ -1,0 +1,6 @@
+defmodule Tus.Storage do
+  @callback create(Tus.File.t(), map()) :: Tus.File.t()
+  @callback append(Tus.File.t(), map(), binary()) :: {:ok, Tus.File.t()} | {:error, term()}
+  @callback complete_upload(Tus.File.t(), map()) :: {:ok, Tus.File.t()} | {:error, term()}
+  @callback delete(Tus.File.t(), map()) :: any()
+end

--- a/lib/tus/storage/local.ex
+++ b/lib/tus/storage/local.ex
@@ -1,6 +1,8 @@
 defmodule Tus.Storage.Local do
   @default_base_path "priv/static/files/"
 
+  @behaviour Tus.Storage
+
   def get_path(uid) do
     uid
     |> String.split("")
@@ -14,7 +16,7 @@ defmodule Tus.Storage.Local do
     |> Path.expand()
   end
 
-  def make_basepath(path, config) do
+  defp make_basepath(path, config) do
     basepath = Path.join([base_path(config), path])
     File.mkdir_p!(basepath)
     basepath

--- a/test/post_test.exs
+++ b/test/post_test.exs
@@ -11,8 +11,10 @@ defmodule Tus.PostTest do
     %{config: get_config()}
   end
 
-  test "`HTTP 413 Request Entity Too Large` if upload larger than the hard config limit", context do
+  test "`HTTP 413 Request Entity Too Large` if upload larger than the hard config limit",
+       context do
     config = context[:config]
+
     conn =
       test_conn(:post, %Plug.Conn{
         req_headers: [
@@ -43,6 +45,7 @@ defmodule Tus.PostTest do
 
   test "hard config limit override the `Tus-Max-Size` soft limit", context do
     config = context[:config]
+
     conn =
       test_conn(:post, %Plug.Conn{
         req_headers: [
@@ -88,10 +91,10 @@ defmodule Tus.PostTest do
   test "parse metadata" do
     metadata_src = "filename d29ybGRfZG9taW5hdGlvbl9wbGFuLnBkZg==,username YnJhaW4="
 
-    expected = [
-      {"filename", "world_domination_plan.pdf"},
-      {"username", "brain"}
-    ]
+    expected = %{
+      "filename" => "world_domination_plan.pdf",
+      "username" => "brain"
+    }
 
     assert Tus.Post.parse_metadata(metadata_src) == expected
   end
@@ -99,10 +102,10 @@ defmodule Tus.PostTest do
   test "parse metadata with invalid spaces" do
     metadata_src = "filename  d29ybGRfZG9taW5hdGlvbl9wbGFuLnBkZg== , username YnJhaW4="
 
-    expected = [
-      {"filename", "world_domination_plan.pdf"},
-      {"username", "brain"}
-    ]
+    expected = %{
+      "filename" => "world_domination_plan.pdf",
+      "username" => "brain"
+    }
 
     assert Tus.Post.parse_metadata(metadata_src) == expected
   end
@@ -128,10 +131,10 @@ defmodule Tus.PostTest do
 
     file = config.cache.get(config.cache_name, uid)
 
-    expected = [
-      {"filename", "world_domination_plan.pdf"},
-      {"username", "brain"}
-    ]
+    expected = %{
+      "filename" => "world_domination_plan.pdf",
+      "username" => "brain"
+    }
 
     assert file
     assert file.metadata_src == metadata_src
@@ -142,6 +145,7 @@ defmodule Tus.PostTest do
 
   test "on_begin_upload called", context do
     config = context[:config]
+
     TestController.post(
       test_conn(:post, %Plug.Conn{
         req_headers: [


### PR DESCRIPTION
I mentioned in [my comment here](https://github.com/jpscaletti/tus/issues/4#issuecomment-489418037) that I found the current implementation too opinionated. However, after thinking it through, the *storage* implementation probably suffices to hook it up to a Broadway pipeline. Well, that's at least what I'm going to try.

But I had to reverse engineer the code to find what the public API of a storage implementation was. Such a contract should be captured in an Elixir behaviour.

This is a small PR to make the storage contract more formal:

* Added `Tus.Storage` Elixir behaviour. 
* Defined the `Tus.File.t/0` typespec: Makes Dialyzer happy.
* Updated the docs slightly.

@jpscaletti can you review and publish this as a new version?